### PR TITLE
Allow React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "babel": "^5.6.14"
   },
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": ">=0.13.3 <0.15.0"
   }
 }


### PR DESCRIPTION
It appears that this component is compatible to React 0.14, so I've relaxed the version constraint to enable React 0.14 to be matched as a peer dependency.
